### PR TITLE
Add 2 missing video subsections to 2026-04-09 digest

### DIFF
--- a/digest/2026-04-09.html
+++ b/digest/2026-04-09.html
@@ -236,7 +236,7 @@
 
 			<header class="header">
 				<h1>AI Builder Digest</h1>
-				<div class="meta">April 9, 2026 &middot; 13 min read</div>
+				<div class="meta">April 9, 2026 &middot; 16 min read</div>
 				<div class="tts-controls" id="tts-controls">
 					<button class="tts-btn" id="tts-btn" onclick="toggleTTS()">
 						<span id="tts-icon">&#9654;</span> <span id="tts-label">Listen</span>
@@ -351,6 +351,29 @@
 <li><strong>Exercise doesn't make you happy it brings you out of the negative</strong>: &quot;Negative-1 without exercise; exercise brings you to zero.&quot; The goal is escaping the dip, not achieving peak happiness.</li>
 <li><strong>Indiana Jones boulder metaphor</strong>: Post ships, immediately onto the next one. The treadmill is the job.</li>
 <li><strong>Practitioners make the best content</strong>: Most of Lenny's best posts are guest posts from practitioners sharing the single best thing they've learned not his own observations.</li>
+</ul>
+<h3>The Real AI Revolution Isn't Software. It's Farms, Mines, and Trucks.</h3>
+<p><strong>Channel:</strong> Lenny's Podcast | <strong>Guest:</strong> Qasar Younis (co-founder &amp; CEO, Applied Intuition) | <strong><a href="https://www.youtube.com/watch?v=_rcniEb9bLw">Watch</a></strong></p>
+<p>Applied Intuition is a $15B under-the-radar AI company bringing autonomy to physical machines — cars, tractors, planes, submarines, mining rigs. 18 of the top 20 automakers plus the DoD are customers. Younis argues the real AI revolution for the next 5-10 years won't be chatbots — it'll be physical AI in industries starving for labor. The average farmer is 58; truck driving went unfilled because the tradeoff (weeks away from family) stopped being worth it when Uber and DoorDash existed. Autonomy arrives just in time, not just in place of.</p>
+<p><strong>Key Takeaways:</strong></p>
+<ul>
+<li><strong>&quot;Go to Detroit airport, sit at a gate, and see how many people know what OpenClaw is. Almost none. The real impact is in physical things.&quot;</strong> The chatbot discourse is a distraction from where AI is actually landing.</li>
+<li><strong>Retrofit, don't build humanoids.</strong> 50-60 years of mechanical engineering is already done on tractors, trucks, rigs. You're just adding intelligence — not reinventing the machine.</li>
+<li><strong>L2++ vs L4 fork</strong>: Tesla's approach (fewer sensors, no HD maps, cheap) goes everywhere soon; Waymo's (more sensors, HD maps, geofenced) goes deep first. Both ubiquitous in 5 years.</li>
+<li><strong>Autonomous driving becomes a free CarPlay-style feature</strong> within 5-7 years — the same pricing trajectory that took nav from $2K add-on to default.</li>
+<li><strong>Hedge fund sell-offs are driven by &quot;AI consultants showing them a cloned Figma in a week&quot;</strong> — not by deep analysis. Vibe-coded replicas reprice real companies.</li>
+</ul>
+<h3>AI Companies Are Building a Copy of Your Brain — and You Won't Own It?</h3>
+<p><strong>Channel:</strong> This Week in AI Podcast | <strong>Guests:</strong> Kanjun Qiu (Imbue), Karina Hong (Axiom Math), Jonathan Siddharth (Turing) | <strong><a href="https://www.youtube.com/watch?v=OVz5LMl3uZY">Watch</a></strong></p>
+<p>A roundtable on why open agent infrastructure matters as &quot;our entire digital lives&quot; get handed to closed AI providers. Covers Anthropic's $30B run rate (up from $9B in six months), formal verification of AI-generated code, Meta's absurd token-burn leaderboard, CEO-automation workflows, and the fork between verticalized closed AI ecosystems and open-source personal intelligence.</p>
+<p><strong>Key Takeaways:</strong></p>
+<ul>
+<li><strong>Anthropic flipped past OpenAI in token revenue.</strong> $30B run rate, up from $9B six months ago. &quot;Everyone Kanjun knows uses Claude Code over Cursor.&quot; Coding is the moat.</li>
+<li><strong>Coding transfers to general reasoning.</strong> Training on code makes models better at finance, law, and strategy because code is low-ambiguity and produces verifiable embeddings. Karina aced Stanford Law exams from a math/physics background because structured legal reasoning is close to math.</li>
+<li><strong>&quot;Search is actually coding.&quot;</strong> When you ask &quot;what are AI trends in 2026?&quot;, the model writes Python, queries PitchBook/Crunchbase via code, plots with matplotlib. You don't see it, but coding is everywhere underneath.</li>
+<li><strong>Formal verification is the real safety answer, not RLHF.</strong> Axiom Math scored 120/120 on Putnam using Lean-based formal proofs — first AI ever, only five humans have done it. &quot;Super intelligence is meaningless if not verified.&quot;</li>
+<li><strong>Meta's token-burn leaderboard is a textbook Goodhart failure.</strong> Engineers write scripts that loop burning tokens to game the metric. Same energy as LOC-based performance reviews.</li>
+<li><strong>Open vs closed AI = organic vs processed food.</strong> Claude/OpenAI is convenient today; open-source personal intelligence is harder but critical for long-term autonomy of your digital life.</li>
 </ul>
 <hr />
 <h2>The Bigger Picture</h2>


### PR DESCRIPTION
Fixes a silent drop where 2 YouTube extracts (Real AI Revolution / Applied Intuition and This Week in AI Ep 8) were chopped by a hardcoded `head -5` cap in `publish-digest.sh`. The cap has been removed in the vault repo; this PR backfills the missing Videos subsections in the already-published digest.